### PR TITLE
feat: Add book reading page with navigation and settings

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "@mui/icons-material": "^6.1.10",
     "@mui/material": "^6.1.10",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { Routes, Route } from 'react-router-dom'
 import {
   AppBar,
   Toolbar,
@@ -11,6 +12,7 @@ import {
   MenuBook,
 } from '@mui/icons-material'
 import BooksLandingPage from './components/BooksLandingPage'
+import BookReaderPage from './components/BookReaderPage'
 import PWABadge from './PWABadge.tsx'
 
 function App() {
@@ -27,7 +29,10 @@ function App() {
         </Toolbar>
       </AppBar>
 
-      <BooksLandingPage />
+      <Routes>
+        <Route path="/" element={<BooksLandingPage />} />
+        <Route path="/read/:bookId" element={<BookReaderPage />} />
+      </Routes>
 
       <PWABadge />
 

--- a/web/src/components/BookReaderPage.tsx
+++ b/web/src/components/BookReaderPage.tsx
@@ -1,0 +1,340 @@
+import { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+  Box,
+  IconButton,
+  Typography,
+  LinearProgress,
+  Paper,
+  useTheme,
+  useMediaQuery,
+  CircularProgress,
+  Alert,
+} from '@mui/material'
+import {
+  ArrowBack,
+  Settings,
+  ChevronLeft,
+  ChevronRight,
+} from '@mui/icons-material'
+import { BookPage, ReaderSettings } from '../types/reader'
+import { fetchBookPage, getBookTotalPages } from '../data/mockBookPages'
+import ReaderSettingsModal from './ReaderSettingsModal'
+
+const STORAGE_KEY = 'flute-reader-settings'
+
+const BookReaderPage = () => {
+  const { bookId } = useParams<{ bookId: string }>()
+  const navigate = useNavigate()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  
+  // State management
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(0)
+  const [pageContent, setPageContent] = useState<BookPage | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settings, setSettings] = useState<ReaderSettings>({
+    fontSize: 16,
+    lineSpacing: 1.5
+  })
+
+  // Load settings from localStorage
+  useEffect(() => {
+    const savedSettings = localStorage.getItem(STORAGE_KEY)
+    if (savedSettings) {
+      try {
+        setSettings(JSON.parse(savedSettings))
+      } catch (e) {
+        console.error('Failed to load reader settings:', e)
+      }
+    }
+  }, [])
+
+  // Initialize page data
+  useEffect(() => {
+    if (bookId) {
+      setTotalPages(getBookTotalPages(bookId))
+      // Load saved progress or start at page 1
+      const savedProgress = localStorage.getItem(`flute-progress-${bookId}`)
+      if (savedProgress) {
+        try {
+          const progress = JSON.parse(savedProgress)
+          setCurrentPage(progress.currentPage || 1)
+        } catch (e) {
+          console.error('Failed to load progress:', e)
+        }
+      }
+    }
+  }, [bookId])
+
+  // Load page content when current page changes
+  useEffect(() => {
+    const loadPage = async () => {
+      if (!bookId) return
+
+      setLoading(true)
+      setError(null)
+      
+      try {
+        const page = await fetchBookPage(bookId, currentPage)
+        setPageContent(page)
+        
+        // Save progress
+        const progress = {
+          currentPage,
+          lastReadDate: new Date().toISOString()
+        }
+        localStorage.setItem(`flute-progress-${bookId}`, JSON.stringify(progress))
+      } catch (err) {
+        setError('Failed to load page content')
+        console.error('Error loading page:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadPage()
+  }, [bookId, currentPage])
+
+  // Handle settings change
+  const handleSettingsChange = (newSettings: ReaderSettings) => {
+    setSettings(newSettings)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings))
+  }
+
+  // Navigation functions
+  const handleBack = () => {
+    navigate('/')
+  }
+
+  const handlePreviousPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1)
+    }
+  }
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1)
+    }
+  }
+
+  // Touch/swipe handlers for mobile
+  useEffect(() => {
+    if (!isMobile) return
+
+    let startX = 0
+    let startY = 0
+
+    const handleTouchStart = (e: TouchEvent) => {
+      startX = e.touches[0].clientX
+      startY = e.touches[0].clientY
+    }
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (!e.changedTouches[0]) return
+
+      const endX = e.changedTouches[0].clientX
+      const endY = e.changedTouches[0].clientY
+      const deltaX = endX - startX
+      const deltaY = endY - startY
+
+      // Only trigger swipe if horizontal movement is greater than vertical
+      if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 50) {
+        if (deltaX > 0) {
+          // Swipe right - previous page
+          handlePreviousPage()
+        } else {
+          // Swipe left - next page
+          handleNextPage()
+        }
+      }
+    }
+
+    const container = scrollContainerRef.current
+    if (container) {
+      container.addEventListener('touchstart', handleTouchStart)
+      container.addEventListener('touchend', handleTouchEnd)
+      
+      return () => {
+        container.removeEventListener('touchstart', handleTouchStart)
+        container.removeEventListener('touchend', handleTouchEnd)
+      }
+    }
+  }, [isMobile, currentPage, totalPages])
+
+  const progressPercentage = totalPages > 0 ? (currentPage / totalPages) * 100 : 0
+
+  if (!bookId) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">Book ID is required</Alert>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ height: 'calc(100vh - 64px)', display: 'flex', flexDirection: 'column' }}>
+      {/* Control Panel */}
+      <Paper elevation={1} sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+        {/* Back Button */}
+        <IconButton onClick={handleBack} aria-label="back to library">
+          <ArrowBack />
+        </IconButton>
+
+        {/* Progress Indicator */}
+        <Box sx={{ flexGrow: 1, mx: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Page {currentPage} of {totalPages}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {Math.round(progressPercentage)}%
+            </Typography>
+          </Box>
+          <LinearProgress
+            variant="determinate"
+            value={progressPercentage}
+            sx={{ height: 6, borderRadius: 3 }}
+          />
+        </Box>
+
+        {/* Settings Button */}
+        <IconButton onClick={() => setSettingsOpen(true)} aria-label="reading settings">
+          <Settings />
+        </IconButton>
+      </Paper>
+
+      {/* Content Area */}
+      <Box
+        ref={scrollContainerRef}
+        sx={{
+          flexGrow: 1,
+          overflow: isMobile ? 'hidden' : 'auto',
+          position: 'relative',
+        }}
+      >
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {error && (
+          <Box sx={{ p: 3 }}>
+            <Alert severity="error">{error}</Alert>
+          </Box>
+        )}
+
+        {pageContent && !loading && (
+          <Box
+            sx={{
+              p: 3,
+              maxWidth: '800px',
+              mx: 'auto',
+              minHeight: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: isMobile ? 'flex-start' : 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontSize: `${settings.fontSize}px`,
+                lineHeight: settings.lineSpacing,
+                whiteSpace: 'pre-line',
+                userSelect: 'text',
+              }}
+            >
+              {pageContent.content}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Mobile Navigation Buttons */}
+        {isMobile && pageContent && !loading && (
+          <>
+            {currentPage > 1 && (
+              <IconButton
+                onClick={handlePreviousPage}
+                sx={{
+                  position: 'absolute',
+                  left: 16,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  backgroundColor: 'background.paper',
+                  boxShadow: 2,
+                  '&:hover': {
+                    backgroundColor: 'background.paper',
+                    boxShadow: 4,
+                  },
+                }}
+                aria-label="previous page"
+              >
+                <ChevronLeft />
+              </IconButton>
+            )}
+
+            {currentPage < totalPages && (
+              <IconButton
+                onClick={handleNextPage}
+                sx={{
+                  position: 'absolute',
+                  right: 16,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  backgroundColor: 'background.paper',
+                  boxShadow: 2,
+                  '&:hover': {
+                    backgroundColor: 'background.paper',
+                    boxShadow: 4,
+                  },
+                }}
+                aria-label="next page"
+              >
+                <ChevronRight />
+              </IconButton>
+            )}
+          </>
+        )}
+      </Box>
+
+      {/* Desktop Navigation */}
+      {!isMobile && pageContent && !loading && (
+        <Paper elevation={1} sx={{ p: 1, display: 'flex', justifyContent: 'center', gap: 2 }}>
+          <IconButton
+            onClick={handlePreviousPage}
+            disabled={currentPage <= 1}
+            aria-label="previous page"
+          >
+            <ChevronLeft />
+          </IconButton>
+          <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', px: 2 }}>
+            Page navigation
+          </Typography>
+          <IconButton
+            onClick={handleNextPage}
+            disabled={currentPage >= totalPages}
+            aria-label="next page"
+          >
+            <ChevronRight />
+          </IconButton>
+        </Paper>
+      )}
+
+      {/* Settings Modal */}
+      <ReaderSettingsModal
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        settings={settings}
+        onSettingsChange={handleSettingsChange}
+      />
+    </Box>
+  )
+}
+
+export default BookReaderPage

--- a/web/src/components/BookTile.tsx
+++ b/web/src/components/BookTile.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import {
   Card,
   CardContent,
@@ -21,6 +22,12 @@ interface BookTileProps {
 }
 
 const BookTile = ({ book }: BookTileProps) => {
+  const navigate = useNavigate()
+
+  const handleClick = () => {
+    navigate(`/read/${book.id}`)
+  }
+
   const formatNumber = (num: number): string => {
     if (num >= 1000) {
       return `${(num / 1000).toFixed(1)}k`
@@ -52,10 +59,12 @@ const BookTile = ({ book }: BookTileProps) => {
 
   return (
     <Card
+      onClick={handleClick}
       sx={{
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        cursor: 'pointer',
         transition: 'transform 0.2s, box-shadow 0.2s',
         '&:hover': {
           transform: 'translateY(-4px)',

--- a/web/src/components/ReaderSettingsModal.tsx
+++ b/web/src/components/ReaderSettingsModal.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Slider,
+  Divider,
+} from '@mui/material'
+import { ReaderSettings } from '../types/reader'
+
+interface ReaderSettingsModalProps {
+  open: boolean
+  onClose: () => void
+  settings: ReaderSettings
+  onSettingsChange: (settings: ReaderSettings) => void
+}
+
+const ReaderSettingsModal = ({ open, onClose, settings, onSettingsChange }: ReaderSettingsModalProps) => {
+  const [tempSettings, setTempSettings] = useState<ReaderSettings>(settings)
+
+  useEffect(() => {
+    setTempSettings(settings)
+  }, [settings])
+
+  const handleSave = () => {
+    onSettingsChange(tempSettings)
+    onClose()
+  }
+
+  const handleCancel = () => {
+    setTempSettings(settings)
+    onClose()
+  }
+
+  const handleFontSizeChange = (_: Event, newValue: number | number[]) => {
+    setTempSettings({
+      ...tempSettings,
+      fontSize: newValue as number
+    })
+  }
+
+  const handleLineSpacingChange = (_: Event, newValue: number | number[]) => {
+    setTempSettings({
+      ...tempSettings,
+      lineSpacing: newValue as number
+    })
+  }
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Reading Settings
+      </DialogTitle>
+      
+      <DialogContent>
+        <Box sx={{ py: 2 }}>
+          {/* Font Size */}
+          <Typography gutterBottom variant="subtitle1" fontWeight="medium">
+            Font Size
+          </Typography>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Adjust the text size for comfortable reading
+          </Typography>
+          <Box sx={{ px: 2, mb: 3 }}>
+            <Slider
+              value={tempSettings.fontSize}
+              onChange={handleFontSizeChange}
+              min={12}
+              max={24}
+              step={1}
+              marks={[
+                { value: 12, label: '12px' },
+                { value: 16, label: '16px' },
+                { value: 20, label: '20px' },
+                { value: 24, label: '24px' },
+              ]}
+              valueLabelDisplay="auto"
+              valueLabelFormat={(value) => `${value}px`}
+            />
+          </Box>
+
+          <Divider sx={{ my: 3 }} />
+
+          {/* Line Spacing */}
+          <Typography gutterBottom variant="subtitle1" fontWeight="medium">
+            Line Spacing
+          </Typography>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Adjust the space between lines of text
+          </Typography>
+          <Box sx={{ px: 2 }}>
+            <Slider
+              value={tempSettings.lineSpacing}
+              onChange={handleLineSpacingChange}
+              min={1.0}
+              max={2.5}
+              step={0.1}
+              marks={[
+                { value: 1.0, label: 'Tight' },
+                { value: 1.5, label: 'Normal' },
+                { value: 2.0, label: 'Loose' },
+                { value: 2.5, label: 'Extra' },
+              ]}
+              valueLabelDisplay="auto"
+              valueLabelFormat={(value) => `${value}x`}
+            />
+          </Box>
+
+          {/* Preview */}
+          <Box sx={{ mt: 4, p: 2, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+            <Typography variant="caption" color="text.secondary" gutterBottom>
+              Preview
+            </Typography>
+            <Typography 
+              sx={{ 
+                fontSize: `${tempSettings.fontSize}px`,
+                lineHeight: tempSettings.lineSpacing,
+                mt: 1
+              }}
+            >
+              This is how your text will appear with the current settings. You can adjust the font size and line spacing to make reading more comfortable for your eyes.
+            </Typography>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleCancel} color="inherit">
+          Cancel
+        </Button>
+        <Button onClick={handleSave} variant="contained">
+          Save Settings
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ReaderSettingsModal

--- a/web/src/data/mockBookPages.ts
+++ b/web/src/data/mockBookPages.ts
@@ -1,0 +1,41 @@
+import { BookPage } from '../types/reader'
+
+// Sample book content for different pages
+const sampleTexts = [
+  "In the beginning, there was darkness. Not the kind of darkness that comes with night, but a profound absence of light that seemed to stretch beyond the boundaries of perception. Maria stood at the edge of the cliff, her eyes searching the vast expanse of the ocean below. The waves crashed against the rocks with a rhythmic persistence that had become the soundtrack to her solitude.\n\nShe had come here every day for the past month, always at the same time, always carrying the same leather-bound journal that her grandmother had given her years ago. The journal contained stories, memories, and dreams that seemed more real than the world around her. Today, however, felt different. There was something in the air, a change that she couldn't quite define but could feel in the depths of her soul.\n\nThe wind picked up, carrying with it the scent of salt and something else - something that reminded her of childhood summers and forgotten laughter. She opened the journal to a blank page and began to write, her pen moving across the paper with a fluidity that surprised her. The words came naturally, as if they had been waiting inside her all along, patient and ready to emerge into the light of day.",
+  
+  "Chapter Two opened with a scene that would haunt readers for generations. The old lighthouse keeper, Thomas, had been alone on the island for fifteen years. His only companions were the seabirds that nested in the rocky crevices and the occasional ship that passed by on clear nights. He had grown accustomed to the isolation, finding solace in the predictable rhythm of his duties.\n\nEach evening, as the sun began its descent toward the horizon, Thomas would climb the spiral staircase to the top of the lighthouse. The stairs creaked under his weight, a familiar symphony that marked the transition from day to night. At the top, he would light the great beacon, its powerful beam sweeping across the dark waters like a guardian angel watching over lost souls.\n\nBut tonight was different. As Thomas reached for the switch that would illuminate the beacon, he noticed something moving in the water below. It wasn't a ship or a whale or any of the usual inhabitants of these waters. It was something else entirely, something that made his heart race and his hands tremble as he pressed his face against the cold glass of the lighthouse window.",
+
+  "The discovery changed everything. What Maria had found in her grandmother's journal wasn't just family history - it was a map, a guide to understanding the strange occurrences that had been happening in the small coastal town for decades. The disappearances, the unexplained lights, the stories that the older residents whispered about but never fully explained.\n\nShe traced the faded ink with her finger, following the careful annotations her grandmother had made in the margins. Each note was dated, some going back fifty years or more. They told a story of vigilance, of watching and waiting, of a responsibility passed down through generations of women in her family.\n\n'The keeper of memories,' one note read, 'must never let the truth fade into legend.' Maria understood now why her grandmother had always seemed so serious, so watchful. She had been guarding something precious and dangerous, something that required constant attention and care. Now that responsibility had passed to Maria, and she wasn't sure she was ready for what it might demand of her.\n\nThe lighthouse beam swept across her window, and for a moment, she could swear she saw a figure standing at the top of the tower, waving in her direction. But when she looked again, there was nothing there but the endless rotation of light against the darkness.",
+
+  "Days turned into weeks as Maria delved deeper into the mystery. She discovered that the lighthouse keeper, Thomas, had been writing his own journal, documenting strange phenomena that occurred on and around the island. Ship logs from the past century mentioned unexplained magnetic disturbances in the area, compasses spinning wildly, and electronic equipment failing without cause.\n\nThe town's library held newspaper clippings dating back to the 1800s, all reporting similar incidents. People would see lights beneath the water, hear music carried on the wind when there were no musicians for miles, and occasionally, someone would simply vanish without a trace, leaving behind only their belongings and a lingering scent of sea salt and jasmine.\n\nMaria realized that her grandmother hadn't just been documenting these events - she had been trying to understand them, to find a pattern or purpose behind the supernatural occurrences. The journal contained sketches of symbols found carved into rocks along the shoreline, translations of ancient texts, and correspondence with scholars from universities around the world.\n\nIt was becoming clear that this small coastal town was situated at the intersection of something much larger and more mysterious than anyone had imagined. The lighthouse wasn't just guiding ships to safety - it was serving as a beacon for something else entirely, something that existed in the spaces between the known and the unknown."
+]
+
+// Generate pages for a specific book
+export const generateBookPages = (bookId: string, totalPages: number = 4): BookPage[] => {
+  return Array.from({ length: totalPages }, (_, index) => ({
+    pageNumber: index + 1,
+    content: sampleTexts[index % sampleTexts.length],
+    wordCount: sampleTexts[index % sampleTexts.length].split(' ').length
+  }))
+}
+
+// Mock API function to fetch a specific page
+export const fetchBookPage = async (bookId: string, pageNumber: number): Promise<BookPage> => {
+  // Simulate API delay
+  await new Promise(resolve => setTimeout(resolve, 300))
+  
+  const pages = generateBookPages(bookId)
+  const page = pages.find(p => p.pageNumber === pageNumber)
+  
+  if (!page) {
+    throw new Error(`Page ${pageNumber} not found for book ${bookId}`)
+  }
+  
+  return page
+}
+
+// Get total pages for a book
+export const getBookTotalPages = (bookId: string): number => {
+  return 4 // For now, all books have 4 pages
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import { theme } from './theme'
@@ -10,7 +11,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/web/src/types/reader.ts
+++ b/web/src/types/reader.ts
@@ -1,0 +1,17 @@
+export interface BookPage {
+  pageNumber: number
+  content: string
+  wordCount: number
+}
+
+export interface ReaderSettings {
+  fontSize: number // in px, default 16
+  lineSpacing: number // multiplier, default 1.5
+}
+
+export interface ReadingProgress {
+  bookId: string
+  currentPage: number
+  totalPages: number
+  lastReadDate: string
+}


### PR DESCRIPTION
Implements a complete book reading experience as requested in issue #21.

## Features
- Responsive book reading page with navigation from book tiles
- Control panel with back button, progress indicator, and settings
- Touch/swipe navigation for mobile devices
- Reader settings with font size and line spacing controls
- LocalStorage persistence for settings and reading progress
- Dummy book content with 4 pages per book
- Responsive design for mobile, tablet, and desktop

## Implementation Details
- Added React Router for navigation
- Created reusable components for reading interface
- Implemented touch gestures for mobile page navigation
- Settings modal with live preview of changes

Closes #21

Generated with [Claude Code](https://claude.ai/code)