### PR TITLE
Add options menu to BookTile component

### DIFF
--- a/web/src/components/BookTile.test.tsx
+++ b/web/src/components/BookTile.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ThemeProvider } from '@mui/material/styles'
+import theme from '../theme'
+import BookTile from './BookTile'
+import { Book } from '../types/book'
+
+const mockBook: Book = {
+  id: '1',
+  title: 'Test Book',
+  coverArt: 'https://example.com/cover.jpg',
+  readProgressRatio: 0.5,
+  wordCount: 50000,
+  knownWords: 25000,
+  learningWords: 15000,
+  unknownWords: 10000,
+  lastReadDate: '2023-12-01T00:00:00Z'
+}
+
+const renderBookTile = (props = {}) => {
+  const defaultProps = {
+    book: mockBook,
+    ...props
+  }
+  
+  return render(
+    <ThemeProvider theme={theme}>
+      <BookTile {...defaultProps} />
+    </ThemeProvider>
+  )
+}
+
+describe('BookTile Options Menu', () => {
+  it('renders BookTile without options menu initially', () => {
+    renderBookTile()
+    
+    expect(screen.getByText('Test Book')).toBeInTheDocument()
+    expect(screen.getByLabelText('book options')).toBeInTheDocument()
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('opens options menu when menu button is clicked', () => {
+    renderBookTile()
+    
+    const menuButton = screen.getByLabelText('book options')
+    fireEvent.click(menuButton)
+    
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+
+  it('closes menu when Edit option is clicked', () => {
+    renderBookTile()
+    
+    const menuButton = screen.getByLabelText('book options')
+    fireEvent.click(menuButton)
+    
+    const editOption = screen.getByText('Edit')
+    fireEvent.click(editOption)
+    
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
+
+  it('closes menu when Archive option is clicked', () => {
+    renderBookTile()
+    
+    const menuButton = screen.getByLabelText('book options')
+    fireEvent.click(menuButton)
+    
+    const archiveOption = screen.getByText('Archive')
+    fireEvent.click(archiveOption)
+    
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  })
+
+  it('closes menu when Delete option is clicked', () => {
+    renderBookTile()
+    
+    const menuButton = screen.getByLabelText('book options')
+    fireEvent.click(menuButton)
+    
+    const deleteOption = screen.getByText('Delete')
+    fireEvent.click(deleteOption)
+    
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('does not trigger card onClick when menu button is clicked', () => {
+    const onClickMock = vi.fn()
+    renderBookTile({ onClick: onClickMock })
+    
+    const menuButton = screen.getByLabelText('book options')
+    fireEvent.click(menuButton)
+    
+    expect(onClickMock).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/BookTile.tsx
+++ b/web/src/components/BookTile.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import {
   Card,
   CardContent,
@@ -8,10 +9,19 @@ import {
   Chip,
   Avatar,
   Stack,
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
 } from '@mui/material'
 import {
   Schedule,
   Book as BookIcon,
+  MoreVert,
+  Edit,
+  Archive,
+  Delete,
 } from '@mui/icons-material'
 import { Book } from '../types/book'
 
@@ -21,6 +31,21 @@ interface BookTileProps {
 }
 
 const BookTile = ({ book, onClick }: BookTileProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const menuOpen = Boolean(anchorEl)
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleMenuItemClick = (action: string) => {
+    handleMenuClose()
+  }
   const formatNumber = (num: number): string => {
     if (num >= 1000) {
       return `${(num / 1000).toFixed(1)}k`
@@ -58,6 +83,7 @@ const BookTile = ({ book, onClick }: BookTileProps) => {
         flexDirection: 'column',
         transition: 'transform 0.2s, box-shadow 0.2s',
         cursor: onClick ? 'pointer' : 'default',
+        position: 'relative',
         '&:hover': {
           transform: 'translateY(-4px)',
           boxShadow: 4,
@@ -156,6 +182,60 @@ const BookTile = ({ book, onClick }: BookTileProps) => {
           </Typography>
         </Box>
       </CardContent>
+      
+      {/* Options Menu Button */}
+      <IconButton
+        aria-label="book options"
+        onClick={handleMenuOpen}
+        sx={{
+          position: 'absolute',
+          bottom: 8,
+          right: 8,
+          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+          backdropFilter: 'blur(4px)',
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 1)',
+          },
+          minWidth: 44,
+          minHeight: 44,
+        }}
+      >
+        <MoreVert />
+      </IconButton>
+
+      {/* Options Menu */}
+      <Menu
+        anchorEl={anchorEl}
+        open={menuOpen}
+        onClose={handleMenuClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <MenuItem onClick={() => handleMenuItemClick('edit')}>
+          <ListItemIcon>
+            <Edit fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => handleMenuItemClick('archive')}>
+          <ListItemIcon>
+            <Archive fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Archive</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => handleMenuItemClick('delete')}>
+          <ListItemIcon>
+            <Delete fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
     </Card>
   )
 }


### PR DESCRIPTION
Implements options menu functionality for BookTile component as requested in issue #39.

## Changes
- Added options menu with Edit/Archive/Delete items
- Menu triggered by icon button in bottom right corner
- Mobile-friendly button with 44px minimum touch target
- Menu closes when any option is clicked
- Added comprehensive smoke tests for menu functionality
- Follows Material-UI patterns with appropriate icons

Closes #39

Generated with [Claude Code](https://claude.ai/code)