### PR TITLE
fix: keep loading indicator visible until all books are loaded

### DIFF
--- a/web/src/components/BooksLandingPage.tsx
+++ b/web/src/components/BooksLandingPage.tsx
@@ -156,7 +156,7 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
       )}
 
       {/* Loading Indicator for Pagination */}
-      {loading && books.length > 0 && (
+      {hasMore && books.length > 0 && (
         <Box display="flex" justifyContent="center" mt={4}>
           <CircularProgress />
         </Box>


### PR DESCRIPTION
Previously, the loading indicator only showed during active fetching, causing users to think they'd reached the end when scrolling quickly to the bottom between fetch operations.

Now the loading indicator remains visible as long as hasMore is true, providing a consistent indication that more books are available.

Fixes #49

Generated with [Claude Code](https://claude.ai/code)