### PR TITLE
Fix landing page full-screen layout on larger devices

### DIFF
--- a/web/src/components/BooksLandingPage.tsx
+++ b/web/src/components/BooksLandingPage.tsx
@@ -100,9 +100,19 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
 
   // Skeleton loader for initial load
   const renderSkeletons = () => (
-    <Grid container spacing={3}>
+    <Grid 
+      container 
+      spacing={3}
+      sx={{
+        // Ensure maximum of 4 columns on larger screens
+        '& > .MuiGrid2-root': {
+          minWidth: { xs: '100%', sm: '50%', md: '33.33%', lg: '25%', xl: '25%' },
+          maxWidth: { xs: '100%', sm: '50%', md: '33.33%', lg: '25%', xl: '25%' },
+        }
+      }}
+    >
       {Array.from({ length: 12 }, (_, i) => (
-        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={`skeleton-${i}`}>
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 3 }} key={`skeleton-${i}`}>
           <Box>
             <Skeleton variant="rectangular" height={200} sx={{ borderRadius: 1 }} />
             <Skeleton variant="text" height={32} sx={{ mt: 1 }} />
@@ -121,7 +131,7 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
   )
 
   return (
-    <Container maxWidth="xl" sx={{ py: 4 }}>
+    <Box sx={{ width: '100%', py: 4, px: 3 }}>
       {/* Header */}
       <Box mb={4}>
         <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
@@ -146,9 +156,19 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
       {books.length === 0 && loading ? (
         renderSkeletons()
       ) : (
-        <Grid container spacing={3}>
+        <Grid 
+          container 
+          spacing={3}
+          sx={{
+            // Ensure maximum of 4 columns on larger screens
+            '& > .MuiGrid2-root': {
+              minWidth: { xs: '100%', sm: '50%', md: '33.33%', lg: '25%', xl: '25%' },
+              maxWidth: { xs: '100%', sm: '50%', md: '33.33%', lg: '25%', xl: '25%' },
+            }
+          }}
+        >
           {books.map((book) => (
-            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={book.id}>
+            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 3 }} key={book.id}>
               <BookTile book={book} onClick={onBookClick} />
             </Grid>
           ))}
@@ -182,7 +202,7 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
           </Typography>
         </Box>
       )}
-    </Container>
+    </Box>
   )
 }
 


### PR DESCRIPTION
Fixes #50

This PR addresses the issue where the landing page wasn't utilizing the full screen width on larger devices.

## Changes
- Replaced Container with maxWidth constraint with full-width Box
- Added explicit grid constraints to maintain 4-tile maximum per row
- Updated both main grid and skeleton loader with consistent breakpoints
- Ensures full screen width utilization while respecting tile limits

## Testing
The layout now properly utilizes full width on larger screens while maintaining:
- 1 tile per row on mobile (xs)
- 2 tiles per row on small tablets (sm)
- 3 tiles per row on medium screens (md)
- 4 tiles per row maximum on large screens (lg/xl)

Generated with [Claude Code](https://claude.ai/code)