### PR TITLE
Configure Claude workflow with mandatory linting/testing tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,5 +48,8 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
+
+          # Allow Claude to run mandatory linting/testing commands
+          claude_args: '--allowed-tools Bash(./server/venv/bin/ruff:*) Bash(./server/venv/bin/pytest:*) Bash(npm:*)'
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
 


### PR DESCRIPTION
## Summary
- Add allowed-tools configuration to Claude workflow
- Enable Claude to run project-specific ruff, pytest, and npm commands
- Ensures Claude can execute mandatory linting and testing as required by project guidelines

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Confirm Claude can execute allowed tools in CI environment

🤖 Generated with [Claude Code](https://claude.ai/code)