### PR TITLE
fix: force Claude Code review to use Sonnet model for Pro subscription

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,8 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Force Sonnet model for Pro subscription compatibility
+          claude_args: '--model claude-sonnet-4 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

This PR modifies the Claude Code review GitHub Action to explicitly use the Sonnet 4 model, which should resolve authentication errors with Pro subscriptions.

## Problem
- Claude Code review action failing with: "This credential is only authorized for use with Claude Code and cannot be used for other API requests"
- Pro subscriptions only have access to Sonnet 4, not Opus 4
- The action may have been trying to use an unauthorized model

## Solution
- Added `--model claude-sonnet-4` to `claude_args` to force Sonnet usage
- This ensures the action stays within Pro subscription model limits
- Should resolve OAuth token authentication issues

Fixes authentication issues related to model access restrictions on Pro subscriptions.