### PR TITLE
Remove word count sort and use separate book count endpoint

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,8 @@
 import { enqueueSnackbar } from 'notistack'
 import type {
   ApiError,
+  BookCountRequest,
+  BookCountResponse,
   BookSummariesRequest,
   BookSummariesResponse,
   CreateBookRequest,
@@ -183,6 +185,14 @@ class ApiClient {
     return response.data
   }
 
+  async getBookCount(request: BookCountRequest): Promise<BookCountResponse> {
+    const response = await this.request<BookCountResponse>('/books/count', {
+      method: 'GET',
+      params: request as unknown as Record<string, unknown>,
+    })
+    return response.data
+  }
+
   // Terms API
   async createTerm(request: CreateTermRequest): Promise<TermIdResponse> {
     const response = await this.request<TermIdResponse>('/terms', {
@@ -213,6 +223,7 @@ export const api = {
   books: {
     create: (request: CreateBookRequest) => apiClient.createBook(request),
     getSummaries: (request: BookSummariesRequest) => apiClient.getBookSummaries(request),
+    getCount: (request: BookCountRequest) => apiClient.getBookCount(request),
   },
   terms: {
     create: (request: CreateTermRequest) => apiClient.createTerm(request),

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -57,6 +57,14 @@ export interface BookSummariesResponse {
   summaries: BookSummary[]
 }
 
+export interface BookCountRequest {
+  language_id: number
+}
+
+export interface BookCountResponse {
+  count: number
+}
+
 // Term types
 export interface UpdateTermRequest {
   status: LearningStatus

--- a/web/src/components/BooksLandingPage.test.tsx
+++ b/web/src/components/BooksLandingPage.test.tsx
@@ -34,9 +34,7 @@ vi.mock('../data/booksService', () => ({
         totalChapters: 20,
       }
     ],
-    hasMore: false,
     nextPage: null,
-    totalCount: 1
   }))
 }))
 

--- a/web/src/components/BooksLandingPage.test.tsx
+++ b/web/src/components/BooksLandingPage.test.tsx
@@ -10,7 +10,8 @@ import theme from '../theme'
 vi.mock('../api', () => ({
   api: {
     books: {
-      getSummaries: vi.fn()
+      getSummaries: vi.fn(),
+      getCount: vi.fn(() => Promise.resolve({ count: 1 }))
     }
   }
 }))

--- a/web/src/components/BooksLandingPage.tsx
+++ b/web/src/components/BooksLandingPage.tsx
@@ -56,12 +56,23 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
 
       if (reset) {
         setBooks(response.books)
+        // Calculate hasMore for reset case
+        const calculatedHasMore = totalCount === 0
+          ? response.books.length > 0
+          : response.books.length < totalCount
+        setHasMore(calculatedHasMore)
       } else {
-        setBooks(prevBooks => [...prevBooks, ...response.books])
+        setBooks(prevBooks => {
+          const newBooks = [...prevBooks, ...response.books]
+          // Calculate hasMore for append case
+          const calculatedHasMore = totalCount === 0
+            ? response.books.length > 0
+            : newBooks.length < totalCount
+          setHasMore(calculatedHasMore)
+          return newBooks
+        })
       }
 
-      // Use the hasMore from the response (based on whether we got a full page)
-      setHasMore(response.hasMore)
       setCurrentPage(page)
     } catch (err) {
       setError('Failed to load books. Please try again.')
@@ -69,7 +80,7 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
     } finally {
       setLoading(false)
     }
-  }, [loading, sortOptions])
+  }, [loading, sortOptions, totalCount])
 
   // Fetch total book count once on mount
   useEffect(() => {

--- a/web/src/components/BooksLandingPage.tsx
+++ b/web/src/components/BooksLandingPage.tsx
@@ -52,27 +52,16 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
     setError(null)
 
     try {
-      // Fetch total count when resetting (initial load or sort change)
-      let totalBookCount = totalCount
-      if (reset) {
-        totalBookCount = await fetchTotalBookCount()
-        setTotalCount(totalBookCount)
-      }
-
       const response = await fetchBooks(page, 12, sortOptions)
 
-      let newBooks: Book[]
       if (reset) {
-        newBooks = response.books
         setBooks(response.books)
       } else {
-        newBooks = [...books, ...response.books]
-        setBooks(newBooks)
+        setBooks(prevBooks => [...prevBooks, ...response.books])
       }
 
-      // Calculate hasMore based on total books loaded vs total available
-      const hasMoreBooks = newBooks.length < totalBookCount
-      setHasMore(hasMoreBooks)
+      // Use the hasMore from the response (based on whether we got a full page)
+      setHasMore(response.hasMore)
       setCurrentPage(page)
     } catch (err) {
       setError('Failed to load books. Please try again.')
@@ -80,7 +69,14 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
     } finally {
       setLoading(false)
     }
-  }, [loading, sortOptions, books, totalCount, fetchTotalBookCount])
+  }, [loading, sortOptions])
+
+  // Fetch total book count once on mount
+  useEffect(() => {
+    fetchTotalBookCount().then(count => {
+      setTotalCount(count)
+    })
+  }, [fetchTotalBookCount])
 
   // Initial load
   useEffect(() => {

--- a/web/src/data/booksService.ts
+++ b/web/src/data/booksService.ts
@@ -47,10 +47,6 @@ function mapSortOptions(sortOptions: SortOptions): { sortOption: SortOption | nu
     case 'unknownWords':
       backendSortOption = SortOption.UNKNOWN_TERMS
       break
-    case 'wordCount':
-      // wordCount doesn't have a direct backend mapping, fall back to title
-      backendSortOption = SortOption.TITLE
-      break
     default:
       backendSortOption = null
   }
@@ -81,14 +77,14 @@ export async function fetchBooks(
 
   const transformedBooks = response.summaries.map(transformBookSummary)
 
-  // Backend doesn't provide hasMore or totalCount in current response
-  // For now, we'll assume there might be more if we got a full page
+  // Backend doesn't provide hasMore or totalCount - these should be calculated by caller
+  // using the separate book count endpoint
   const hasMore = response.summaries.length === pageSize
 
   return {
     books: transformedBooks,
     hasMore,
     nextPage: hasMore ? page + 1 : null,
-    totalCount: transformedBooks.length, // Backend doesn't provide total count yet
+    totalCount: 0, // No longer calculated here - use separate book count endpoint
   }
 }

--- a/web/src/data/booksService.ts
+++ b/web/src/data/booksService.ts
@@ -79,11 +79,10 @@ export async function fetchBooks(
 
   // Backend doesn't provide hasMore or totalCount - these should be calculated by caller
   // using the separate book count endpoint
-  const hasMore = response.summaries.length === pageSize
+  const hasNextPage = response.summaries.length === pageSize
 
   return {
     books: transformedBooks,
-    hasMore,
-    nextPage: hasMore ? page + 1 : null,
+    nextPage: hasNextPage ? page + 1 : null,
   }
 }

--- a/web/src/data/booksService.ts
+++ b/web/src/data/booksService.ts
@@ -85,6 +85,5 @@ export async function fetchBooks(
     books: transformedBooks,
     hasMore,
     nextPage: hasMore ? page + 1 : null,
-    totalCount: 0, // No longer calculated here - use separate book count endpoint
   }
 }

--- a/web/src/data/mockBooks.ts
+++ b/web/src/data/mockBooks.ts
@@ -59,9 +59,6 @@ const sortBooks = (books: Book[], sortOptions: SortOptions): Book[] => {
       case 'alphabetical':
         comparison = a.title.localeCompare(b.title)
         break
-      case 'wordCount':
-        comparison = a.wordCount - b.wordCount
-        break
       case 'unknownWords':
         comparison = a.unknownWords - b.unknownWords
         break

--- a/web/src/types/book.ts
+++ b/web/src/types/book.ts
@@ -16,5 +16,4 @@ export interface BooksPaginationResponse {
   books: Book[]
   hasMore: boolean
   nextPage: number | null
-  totalCount: number
 }

--- a/web/src/types/book.ts
+++ b/web/src/types/book.ts
@@ -14,6 +14,5 @@ export interface Book {
 
 export interface BooksPaginationResponse {
   books: Book[]
-  hasMore: boolean
   nextPage: number | null
 }

--- a/web/src/types/sorting.ts
+++ b/web/src/types/sorting.ts
@@ -1,4 +1,4 @@
-export type SortField = 'lastRead' | 'alphabetical' | 'wordCount' | 'unknownWords' | 'learningWords'
+export type SortField = 'lastRead' | 'alphabetical' | 'unknownWords' | 'learningWords'
 export type SortOrder = 'asc' | 'desc'
 
 export interface SortOptions {
@@ -9,7 +9,6 @@ export interface SortOptions {
 export const SORT_FIELD_LABELS: Record<SortField, string> = {
   lastRead: 'By last read',
   alphabetical: 'Alphabetically',
-  wordCount: 'By word count',
   unknownWords: 'By unknown words',
   learningWords: 'By learning words',
 }


### PR DESCRIPTION
Addresses follow-up issues from PR #70 review feedback:

- Remove expectation that books summary endpoint provides total count and hasMore
- Update landing page to use separate book count endpoint from PR #73
- Remove word count sort option completely

Closes #77

Generated with [Claude Code](https://claude.ai/code)