### PR TITLE
feat: extend Language model with flag image support and books filter

### DIFF
--- a/server/src/models/language.py
+++ b/server/src/models/language.py
@@ -12,6 +12,7 @@ class Language(db.Model, AuditMixin):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(40), nullable=False)
+    flag_image_filepath: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     character_substitutions: Mapped[str] = mapped_column(
         String(500), nullable=False, default="´='|`='|'='|'='|...=…|..=‥"


### PR DESCRIPTION
Extends the Language model and API endpoints with:

- Nullable flag_image_filepath field (String(500))
- Updated all language endpoints to support flag images
- New with_books query parameter for filtering languages
- Comprehensive test coverage

Closes #78

Generated with [Claude Code](https://claude.ai/code)