### PR TITLE
feat: Implement book image fetching from backend

### DIFF
--- a/web/src/components/BookTile.tsx
+++ b/web/src/components/BookTile.tsx
@@ -32,6 +32,7 @@ interface BookTileProps {
 
 const BookTile = ({ book, onClick }: BookTileProps) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const [imageError, setImageError] = React.useState(false)
   const menuOpen = Boolean(anchorEl)
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -45,6 +46,10 @@ const BookTile = ({ book, onClick }: BookTileProps) => {
 
   const handleMenuItemClick = (_action: string) => {
     handleMenuClose()
+  }
+
+  const handleImageError = () => {
+    setImageError(true)
   }
   const formatNumber = (num: number): string => {
     if (num >= 1000) {
@@ -91,16 +96,38 @@ const BookTile = ({ book, onClick }: BookTileProps) => {
       }}
       onClick={() => onClick?.(book)}
     >
-      <CardMedia
-        component="img"
-        image={book.coverArt}
-        alt={book.title}
-        sx={{
-          objectFit: 'cover',
-          width: '100%',
-          height: { xs: 180, sm: 200 },
-        }}
-      />
+      {imageError ? (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            width: '100%',
+            height: { xs: 180, sm: 200 },
+            backgroundColor: 'grey.100',
+            color: 'grey.500',
+            gap: 1,
+          }}
+        >
+          <BookIcon sx={{ fontSize: { xs: 48, sm: 56 } }} />
+          <Typography variant="body2" align="center" sx={{ px: 2 }}>
+            No Cover Available
+          </Typography>
+        </Box>
+      ) : (
+        <CardMedia
+          component="img"
+          image={book.coverArt}
+          alt={book.title}
+          onError={handleImageError}
+          sx={{
+            objectFit: 'cover',
+            width: '100%',
+            height: { xs: 180, sm: 200 },
+          }}
+        />
+      )}
       
       <CardContent sx={{ flexGrow: 1, pb: 2, px: { xs: 2, sm: 2 }, py: { xs: 1.5, sm: 2 } }}>
         <Typography

--- a/web/src/data/booksService.ts
+++ b/web/src/data/booksService.ts
@@ -11,10 +11,15 @@ const DEFAULT_LANGUAGE_ID = 1
  * Maps backend BookSummary to frontend Book format
  */
 function transformBookSummary(summary: BookSummary): Book {
+  // Use backend image API if cover art exists, otherwise use placeholder
+  const coverArtUrl = summary.cover_art_filepath
+    ? `/api/images/${summary.cover_art_filepath}`
+    : `https://picsum.photos/300/400?random=${summary.book_id}`
+
   return {
     id: summary.book_id.toString(),
     title: summary.title,
-    coverArt: summary.cover_art_filepath || `https://picsum.photos/300/400?random=${summary.book_id}`,
+    coverArt: coverArtUrl,
     wordCount: summary.total_terms,
     unknownWords: summary.unknown_terms,
     learningWords: summary.learning_terms,


### PR DESCRIPTION
This PR implements book image fetching from the backend API instead of using placeholder images.

## Changes:

- **Backend Integration**: Updated `booksService.ts` to use `/api/images/{filepath}` for book covers
- **Error Handling**: Enhanced `BookTile.tsx` with graceful fallback for missing/failed images
- **Fallback UI**: Added attractive "No Cover Available" placeholder with book icon
- **Backward Compatibility**: Maintains existing placeholder behavior for null cover art paths

Closes #87

Generated with [Claude Code](https://claude.ai/code)