### PR TITLE
Add language options to landing page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { BrowserRouter as Router, Routes, Route, useNavigate } from 'react-route
 import BooksLandingPage from './components/BooksLandingPage'
 import BookReader from './components/BookReader'
 import BookUpload from './components/BookUpload'
+import LanguageChooser from './components/LanguageChooser'
 import PWABadge from './PWABadge.tsx'
 import { Book } from './types/book'
 import StoreProvider from './store/StoreProvider'
@@ -35,7 +36,8 @@ function LibraryPage() {
     <Box sx={{ flexGrow: 1, minHeight: '100vh', bgcolor: 'background.default' }}>
       <AppBar position="static">
         <Toolbar>
-          <MenuBook sx={{ mr: 2 }} />
+          <LanguageChooser />
+          <MenuBook sx={{ mr: 2, ml: 1 }} />
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             Flute - Your Reading Companion
           </Typography>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,12 @@ import type {
   CreateBookResponse,
   CreateTermRequest,
   HealthCheckResponse,
+  LanguageCreate,
+  LanguageCreateResponse,
+  LanguageDetail,
+  LanguageSummariesRequest,
+  LanguageSummariesResponse,
+  LanguageUpdate,
   TermIdResponse,
   UpdateTermRequest,
 } from './types'
@@ -208,6 +214,37 @@ class ApiClient {
       body: request,
     })
   }
+
+  // Languages API
+  async getLanguageSummaries(request: LanguageSummariesRequest = {}): Promise<LanguageSummariesResponse> {
+    const response = await this.request<LanguageSummariesResponse>('/languages', {
+      method: 'GET',
+      params: request as unknown as Record<string, unknown>,
+    })
+    return response.data
+  }
+
+  async getLanguageDetail(languageId: number): Promise<LanguageDetail> {
+    const response = await this.request<LanguageDetail>(`/languages/${languageId}`, {
+      method: 'GET',
+    })
+    return response.data
+  }
+
+  async createLanguage(request: LanguageCreate): Promise<LanguageCreateResponse> {
+    const response = await this.request<LanguageCreateResponse>('/languages', {
+      method: 'POST',
+      body: request,
+    })
+    return response.data
+  }
+
+  async updateLanguage(languageId: number, request: LanguageUpdate): Promise<void> {
+    await this.request<void>(`/languages/${languageId}`, {
+      method: 'PATCH',
+      body: request,
+    })
+  }
 }
 
 // Create and export a singleton instance
@@ -228,5 +265,11 @@ export const api = {
   terms: {
     create: (request: CreateTermRequest) => apiClient.createTerm(request),
     update: (termId: number, request: UpdateTermRequest) => apiClient.updateTerm(termId, request),
+  },
+  languages: {
+    getSummaries: (request: LanguageSummariesRequest = {}) => apiClient.getLanguageSummaries(request),
+    getDetail: (languageId: number) => apiClient.getLanguageDetail(languageId),
+    create: (request: LanguageCreate) => apiClient.createLanguage(request),
+    update: (languageId: number, request: LanguageUpdate) => apiClient.updateLanguage(languageId, request),
   },
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -82,6 +82,62 @@ export interface TermIdResponse {
   term_id: number
 }
 
+// Language types
+export interface LanguageSummary {
+  id: number
+  name: string
+  flag_image_filepath: string | null
+}
+
+export interface LanguageDetail {
+  id: number
+  name: string
+  flag_image_filepath: string | null
+  character_substitutions: string
+  regexp_split_sentences: string
+  exceptions_split_sentences: string
+  word_characters: string
+  right_to_left: boolean
+  show_romanization: boolean
+  parser_type: string
+}
+
+export interface LanguageCreate {
+  name: string
+  flag_image_filepath?: string | null
+  character_substitutions?: string
+  regexp_split_sentences?: string
+  exceptions_split_sentences?: string
+  word_characters?: string
+  right_to_left?: boolean
+  show_romanization?: boolean
+  parser_type?: string
+}
+
+export interface LanguageUpdate {
+  name?: string
+  flag_image_filepath?: string | null
+  character_substitutions?: string
+  regexp_split_sentences?: string
+  exceptions_split_sentences?: string
+  word_characters?: string
+  right_to_left?: boolean
+  show_romanization?: boolean
+  parser_type?: string
+}
+
+export interface LanguageCreateResponse {
+  language_id: number
+}
+
+export interface LanguageSummariesRequest {
+  with_books?: boolean
+}
+
+export interface LanguageSummariesResponse {
+  languages: LanguageSummary[]
+}
+
 // Error types
 export interface ApiError {
   error: string

--- a/web/src/components/BooksLandingPage.tsx
+++ b/web/src/components/BooksLandingPage.tsx
@@ -13,12 +13,9 @@ import { Book } from '../types/book'
 import { SortOptions } from '../types/sorting'
 import { fetchBooks } from '../data/booksService'
 import { api } from '../api'
-import { bookSortOptionsAtom } from '../store/atoms'
+import { bookSortOptionsAtom, selectedLanguageAtom } from '../store/atoms'
 import BookTile from './BookTile'
 import BooksSortControls from './BooksSortControls'
-
-// Default language ID - in a real app this would come from user settings
-const DEFAULT_LANGUAGE_ID = 1
 
 interface BooksLandingPageProps {
   onBookClick?: (book: Book) => void
@@ -32,27 +29,30 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
   const [currentPage, setCurrentPage] = useState(1)
   const [totalCount, setTotalCount] = useState(0)
   const [sortOptions, setSortOptions] = useAtom(bookSortOptionsAtom)
+  const [selectedLanguage] = useAtom(selectedLanguageAtom)
 
   // Function to fetch total book count
   const fetchTotalBookCount = useCallback(async () => {
+    if (!selectedLanguage) return 0
+
     try {
-      const response = await api.books.getCount({ language_id: DEFAULT_LANGUAGE_ID })
+      const response = await api.books.getCount({ language_id: selectedLanguage.id })
       return response.count
     } catch (err) {
       console.error('Error fetching book count:', err)
       return 0
     }
-  }, [])
+  }, [selectedLanguage])
 
   // Function to load more books
   const loadBooks = useCallback(async (page: number, reset: boolean = false) => {
-    if (loading) return
+    if (loading || !selectedLanguage) return
 
     setLoading(true)
     setError(null)
 
     try {
-      const response = await fetchBooks(page, 12, sortOptions)
+      const response = await fetchBooks(page, 12, sortOptions, selectedLanguage.id)
 
       if (reset) {
         setBooks(response.books)
@@ -80,26 +80,24 @@ const BooksLandingPage = ({ onBookClick }: BooksLandingPageProps) => {
     } finally {
       setLoading(false)
     }
-  }, [loading, sortOptions, totalCount])
+  }, [loading, sortOptions, totalCount, selectedLanguage])
 
-  // Fetch total book count once on mount
+  // Fetch total book count when language changes
   useEffect(() => {
-    fetchTotalBookCount().then(count => {
-      setTotalCount(count)
-    })
-  }, [fetchTotalBookCount])
+    if (selectedLanguage) {
+      fetchTotalBookCount().then(count => {
+        setTotalCount(count)
+      })
+    }
+  }, [fetchTotalBookCount, selectedLanguage])
 
-  // Initial load
+  // Load books when language or sort options change
   useEffect(() => {
-    loadBooks(1, true)
+    if (selectedLanguage) {
+      loadBooks(1, true)
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Reload books when sort options change
-  useEffect(() => {
-    loadBooks(1, true)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortOptions])
+  }, [selectedLanguage, sortOptions])
 
   // Handle sort change
   const handleSortChange = (newSortOptions: SortOptions) => {

--- a/web/src/components/LanguageChooser.tsx
+++ b/web/src/components/LanguageChooser.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  IconButton,
+  Menu,
+  MenuItem,
+  Typography,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  CircularProgress,
+  Alert,
+} from '@mui/material'
+import {
+  Language as LanguageIcon,
+  Add as AddIcon,
+} from '@mui/icons-material'
+import { useAtom } from 'jotai'
+import { selectedLanguageAtom } from '../store/atoms'
+import { api } from '../api'
+import { LanguageSummary } from '../api/types'
+
+const LanguageChooser = () => {
+  const [selectedLanguage, setSelectedLanguage] = useAtom(selectedLanguageAtom)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const [languages, setLanguages] = useState<LanguageSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const open = Boolean(anchorEl)
+
+  const loadLanguages = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await api.languages.getSummaries({ with_books: true })
+      setLanguages(response.languages)
+
+      // If no language is selected, select the first one with books
+      if (!selectedLanguage && response.languages.length > 0) {
+        setSelectedLanguage(response.languages[0])
+      }
+    } catch (err) {
+      setError('Failed to load languages')
+      console.error('Error loading languages:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedLanguage, setSelectedLanguage])
+
+  // Load languages when component mounts or when menu opens
+  useEffect(() => {
+    if (open && languages.length === 0) {
+      loadLanguages()
+    }
+  }, [open, languages.length, loadLanguages])
+
+  // Load selected language on mount if not already loaded
+  useEffect(() => {
+    if (!selectedLanguage) {
+      loadLanguages()
+    }
+  }, [selectedLanguage, loadLanguages])
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleLanguageSelect = (language: LanguageSummary) => {
+    setSelectedLanguage(language)
+    handleClose()
+  }
+
+  const handleAddLanguage = () => {
+    // TODO: Implement add language functionality
+    console.log('Add new language clicked')
+    handleClose()
+  }
+
+  const renderLanguageDisplay = (language: LanguageSummary) => {
+    if (language.flag_image_filepath) {
+      return (
+        <img
+          src={language.flag_image_filepath}
+          alt={`${language.name} flag`}
+          style={{
+            width: 24,
+            height: 16,
+            objectFit: 'cover',
+            borderRadius: 2,
+          }}
+        />
+      )
+    }
+    return (
+      <Typography variant="body2" color="inherit">
+        {language.name}
+      </Typography>
+    )
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error" sx={{ minWidth: 200 }}>
+        {error}
+      </Alert>
+    )
+  }
+
+  return (
+    <>
+      <IconButton
+        onClick={handleClick}
+        size="small"
+        sx={{ ml: 1 }}
+        aria-controls={open ? 'language-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        disabled={loading}
+      >
+        {loading ? (
+          <CircularProgress size={24} color="inherit" />
+        ) : selectedLanguage ? (
+          renderLanguageDisplay(selectedLanguage)
+        ) : (
+          <LanguageIcon />
+        )}
+      </IconButton>
+
+      <Menu
+        id="language-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'language-button',
+        }}
+        transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+      >
+        {languages.map((language) => (
+          <MenuItem
+            key={language.id}
+            onClick={() => handleLanguageSelect(language)}
+            selected={selectedLanguage?.id === language.id}
+          >
+            <ListItemIcon sx={{ minWidth: 40 }}>
+              {language.flag_image_filepath ? (
+                <img
+                  src={language.flag_image_filepath}
+                  alt={`${language.name} flag`}
+                  style={{
+                    width: 24,
+                    height: 16,
+                    objectFit: 'cover',
+                    borderRadius: 2,
+                  }}
+                />
+              ) : (
+                <LanguageIcon />
+              )}
+            </ListItemIcon>
+            <ListItemText primary={language.name} />
+          </MenuItem>
+        ))}
+
+        {languages.length > 0 && (
+          <Divider />
+        )}
+
+        <MenuItem onClick={handleAddLanguage}>
+          <ListItemIcon>
+            <AddIcon />
+          </ListItemIcon>
+          <ListItemText primary="Add new language" />
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default LanguageChooser

--- a/web/src/store/atoms.ts
+++ b/web/src/store/atoms.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { SortOptions, DEFAULT_SORT_OPTIONS } from '../types/sorting'
+import { LanguageSummary } from '../api/types'
 
 // Types for our persistent data
 export interface ReaderSettings {
@@ -145,6 +146,16 @@ export const endReadingSessionAtom = atom(
 export const bookSortOptionsAtom = atomWithStorage<SortOptions>(
   'flute-book-sort-options',
   DEFAULT_SORT_OPTIONS,
+  undefined,
+  {
+    getOnInit: true,
+  }
+)
+
+// Selected language (stored persistently)
+export const selectedLanguageAtom = atomWithStorage<LanguageSummary | null>(
+  'flute-selected-language',
+  null,
   undefined,
   {
     getOnInit: true,


### PR DESCRIPTION
Implements issue #88: Add language chooser to landing page toolbar

✅ Language chooser in top-left of app toolbar
✅ Populated with languages that have books (with_books=true)
✅ Persistent language selection using jotai atomWithStorage
✅ Flag images with text fallback
✅ Dropdown with all languages + "Add new language" dummy button
✅ Books summary endpoint uses selected language

Generated with [Claude Code](https://claude.ai/code)