### PR TITLE
feat: replace placeholders with real backend data in book summaries

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -51,6 +51,9 @@ export interface BookSummary {
   known_terms: number
   learning_terms: number
   unknown_terms: number
+  last_visited_chapter: number | null
+  last_visited_word_index: number | null
+  last_read: string | null
 }
 
 export interface BookSummariesResponse {

--- a/web/src/data/booksService.ts
+++ b/web/src/data/booksService.ts
@@ -24,12 +24,10 @@ function transformBookSummary(summary: BookSummary): Book {
     unknownWords: summary.unknown_terms,
     learningWords: summary.learning_terms,
     knownWords: summary.known_terms,
-    // Mock data for fields not available from backend
-    // In a real implementation, these would come from additional API calls
-    lastReadDate: new Date().toISOString(),
+    lastReadDate: summary.last_read ?? '',
     readProgressRatio: summary.total_terms > 0 ? summary.known_terms / summary.total_terms : 0,
-    totalChapters: 20, // Default placeholder
-    lastReadChapter: 1,
+    totalChapters: 20, // Placeholder - requires separate chapter count endpoint
+    lastReadChapter: summary.last_visited_chapter ?? undefined,
   }
 }
 


### PR DESCRIPTION
Replaces placeholders for `lastReadDate` and `lastReadChapter` with real backend data from PR #82.

## Changes
- Added `last_visited_chapter`, `last_visited_word_index`, and `last_read` fields to `BookSummary` interface
- Updated `transformBookSummary()` to use actual backend data
- Use empty string for `lastReadDate` when null (better UX for never-read books)
- Use undefined for `lastReadChapter` when null (field is optional)

## Note
`totalChapters` remains a placeholder as it would require individual API calls per book, which is inefficient for the summaries list view.

Closes #91

Generated with [Claude Code](https://claude.ai/code)