### PR TITLE
Replace mock data with backend API calls in BookReader

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   BookCountResponse,
   BookSummariesRequest,
   BookSummariesResponse,
+  ChapterCountResponse,
+  ChapterWithHighlightsResponse,
   CreateBookRequest,
   CreateBookResponse,
   CreateTermRequest,
@@ -199,6 +201,23 @@ class ApiClient {
     return response.data
   }
 
+  async getChapterWithHighlights(bookId: number, chapterNumber: number): Promise<ChapterWithHighlightsResponse> {
+    const response = await this.request<ChapterWithHighlightsResponse>(
+      `/books/${bookId}/chapters/${chapterNumber}`,
+      {
+        method: 'GET',
+      }
+    )
+    return response.data
+  }
+
+  async getChapterCount(bookId: number): Promise<ChapterCountResponse> {
+    const response = await this.request<ChapterCountResponse>(`/books/${bookId}/chapters/count`, {
+      method: 'GET',
+    })
+    return response.data
+  }
+
   // Terms API
   async createTerm(request: CreateTermRequest): Promise<TermIdResponse> {
     const response = await this.request<TermIdResponse>('/terms', {
@@ -261,6 +280,9 @@ export const api = {
     create: (request: CreateBookRequest) => apiClient.createBook(request),
     getSummaries: (request: BookSummariesRequest) => apiClient.getBookSummaries(request),
     getCount: (request: BookCountRequest) => apiClient.getBookCount(request),
+    getChapterWithHighlights: (bookId: number, chapterNumber: number) =>
+      apiClient.getChapterWithHighlights(bookId, chapterNumber),
+    getChapterCount: (bookId: number) => apiClient.getChapterCount(bookId),
   },
   terms: {
     create: (request: CreateTermRequest) => apiClient.createTerm(request),

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -65,6 +65,32 @@ export interface BookCountResponse {
   count: number
 }
 
+// Chapter types
+export interface ChapterResponse {
+  id: number
+  chapter_number: number
+  content: string
+  word_count: number
+}
+
+export interface TermHighlight {
+  term_id: number
+  display: string
+  start_pos: number
+  end_pos: number
+  status: LearningStatus
+  learning_stage: number | null
+}
+
+export interface ChapterWithHighlightsResponse {
+  chapter: ChapterResponse
+  term_highlights: TermHighlight[]
+}
+
+export interface ChapterCountResponse {
+  count: number
+}
+
 // Term types
 export interface UpdateTermRequest {
   status: LearningStatus

--- a/web/src/components/BookReader.test.tsx
+++ b/web/src/components/BookReader.test.tsx
@@ -124,4 +124,77 @@ describe('BookReader', () => {
       { timeout: 3000 }
     )
   })
+
+  it('loads book from URL parameters', async () => {
+    const { fetchBooks } = await import('../data/mockBooks')
+
+    const mockBook = {
+      id: '1',
+      title: 'URL Loaded Book',
+      coverArt: '/url-test.jpg',
+      wordCount: 2000,
+      unknownWords: 200,
+      learningWords: 100,
+      knownWords: 1700,
+      lastReadDate: '2025-01-01',
+      readProgressRatio: 0.3,
+      totalChapters: 15,
+      lastReadChapter: 5,
+    }
+
+    const mockChapterResponse = {
+      chapter: {
+        id: 1,
+        chapter_number: 3,
+        content: 'Content loaded from URL parameters.',
+        word_count: 5,
+      },
+      term_highlights: [],
+    }
+
+    const mockChapterCountResponse = {
+      count: 15,
+    }
+
+    vi.mocked(fetchBooks).mockResolvedValue({
+      books: [mockBook],
+      hasMore: false,
+      nextPage: null,
+      totalCount: 1,
+    })
+    vi.mocked(api.books.getChapterWithHighlights).mockResolvedValue(mockChapterResponse)
+    vi.mocked(api.books.getChapterCount).mockResolvedValue(mockChapterCountResponse)
+
+    render(
+      <MemoryRouter initialEntries={['/book/1/chapter/3']}>
+        <Routes>
+          <Route path="/book/:bookId/chapter/:chapterId" element={<BookReader />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // Should show loading initially
+    expect(screen.getByText('Loading book...')).toBeInTheDocument()
+
+    // Should load book data and chapter count
+    await waitFor(() => {
+      expect(fetchBooks).toHaveBeenCalled()
+      expect(api.books.getChapterCount).toHaveBeenCalledWith(1)
+    })
+
+    // Should display book title and chapter content
+    await waitFor(() => {
+      expect(screen.getByText('URL Loaded Book')).toBeInTheDocument()
+    })
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Content loaded from URL parameters.')).toBeInTheDocument()
+      },
+      { timeout: 3000 }
+    )
+
+    // Verify API calls were made with correct parameters
+    expect(api.books.getChapterWithHighlights).toHaveBeenCalledWith(1, 3)
+  })
 })

--- a/web/src/components/BookReader.test.tsx
+++ b/web/src/components/BookReader.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import BookReader from './BookReader'
+import { api } from '../api'
+
+vi.mock('../api', () => ({
+  api: {
+    books: {
+      getChapterWithHighlights: vi.fn(),
+      getChapterCount: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../data/mockBooks', () => ({
+  fetchBooks: vi.fn(),
+}))
+
+vi.mock('../hooks/useBookProgress', () => ({
+  default: () => ({
+    updateBookProgress: vi.fn(),
+    startReadingSession: vi.fn(),
+    endReadingSession: vi.fn(),
+  }),
+}))
+
+describe('BookReader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders loading state initially', () => {
+    render(
+      <MemoryRouter initialEntries={['/book/1/chapter/1']}>
+        <Routes>
+          <Route path="/book/:bookId/chapter/:chapterId" element={<BookReader />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Loading book...')).toBeInTheDocument()
+  })
+
+  it('loads and displays chapter content from API', async () => {
+    const mockBook = {
+      id: '1',
+      title: 'Test Book',
+      coverArt: '/test.jpg',
+      wordCount: 1000,
+      unknownWords: 100,
+      learningWords: 50,
+      knownWords: 850,
+      lastReadDate: '2025-01-01',
+      readProgressRatio: 0.5,
+      totalChapters: 10,
+      lastReadChapter: 1,
+    }
+
+    const mockChapterResponse = {
+      chapter: {
+        id: 1,
+        chapter_number: 1,
+        content: 'This is the test chapter content.',
+        word_count: 6,
+      },
+      term_highlights: [],
+    }
+
+    const mockChapterCountResponse = {
+      count: 10,
+    }
+
+    vi.mocked(api.books.getChapterWithHighlights).mockResolvedValue(mockChapterResponse)
+    vi.mocked(api.books.getChapterCount).mockResolvedValue(mockChapterCountResponse)
+
+    render(
+      <MemoryRouter>
+        <BookReader book={mockBook} chapter={1} />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Book')).toBeInTheDocument()
+    })
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('This is the test chapter content.')).toBeInTheDocument()
+      },
+      { timeout: 3000 }
+    )
+
+    expect(api.books.getChapterWithHighlights).toHaveBeenCalledWith(1, 1)
+  })
+
+  it('handles API errors gracefully', async () => {
+    const mockBook = {
+      id: '1',
+      title: 'Test Book',
+      coverArt: '/test.jpg',
+      wordCount: 1000,
+      unknownWords: 100,
+      learningWords: 50,
+      knownWords: 850,
+      lastReadDate: '2025-01-01',
+      readProgressRatio: 0.5,
+      totalChapters: 10,
+      lastReadChapter: 1,
+    }
+
+    vi.mocked(api.books.getChapterWithHighlights).mockRejectedValue(new Error('API Error'))
+
+    render(
+      <MemoryRouter>
+        <BookReader book={mockBook} chapter={1} />
+      </MemoryRouter>
+    )
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Failed to load chapter content')).toBeInTheDocument()
+      },
+      { timeout: 3000 }
+    )
+  })
+})


### PR DESCRIPTION
Fixes #93

This PR replaces the mock chapter data in the BookReader component with actual backend API calls.

## Changes
- Added API types for chapter endpoints
- Added API client methods for fetching chapter content and chapter count
- Updated BookReader to use backend API instead of mock data
- Book ID and chapter number from URL are used to fetch content
- Chapter count is fetched separately as a constant for the book
- Added high-level tests for BookReader

Text highlights from the backend response are ignored for now as requested.

🤖 Generated with [Claude Code](https://claude.ai/code)